### PR TITLE
Using signed values for layer boundaries.

### DIFF
--- a/psdparser.py
+++ b/psdparser.py
@@ -390,7 +390,7 @@ class PSDParser():
                     #
                     # Layer Info
                     #
-                    (l['top'], l['left'], l['bottom'], l['right'], l['channels']) = self._readf(">LLLLH")
+                    (l['top'], l['left'], l['bottom'], l['right'], l['channels']) = self._readf(">llllH")
                     (l['rows'], l['cols']) = (l['bottom'] - l['top'], l['right'] - l['left'])
                     logging.debug(INDENT_OUTPUT(1, "layer %(idx)d: (%(left)4d,%(top)4d,%(right)4d,%(bottom)4d), %(channels)d channels (%(cols)4d cols x %(rows)4d rows)" % l))
                     


### PR DESCRIPTION
It is possible, with GIMP 2.6 at least, to make a layer that has negative boundary locations where the layer is to the left or above the image canvas. 
This change reads the values as signed integers.
