### PR TITLE
Support for Alpha channel in PSD merged image data.

### DIFF
--- a/psdparser.py
+++ b/psdparser.py
@@ -371,7 +371,7 @@ class PSDParser():
             (layerlen,) = self._readf(">L")
             if layerlen:
                 # layers structure
-                (self.num_layers,) = self._readf(">H")
+                (self.num_layers,) = self._readf(">h")
                 if self.num_layers < 0:
                     self.num_layers = -self.num_layers
                     logging.debug(INDENT_OUTPUT(1, "First alpha is transparency for merged image"))
@@ -537,6 +537,8 @@ class PSDParser():
             self.merged_image = self.merged_image[0]
         elif li['channels'] == 3:
             self.merged_image = Image.merge('RGB', self.merged_image)
+        elif li['channels'] == 4 and self.header['mode'] == 3:
+            self.merged_image = Image.merge('RGBA', self.merged_image)
         else:
             raise ValueError('Unsupported number of channels')
 


### PR DESCRIPTION
1. Using '>h' to read signed short for layer count.
2. Reading 'RGBA' for merged data with channel count 4,
   and color mode 3.

For a PSD with transparency a negative layer count in
the layer info struct its absolute value is the number
of layers and the first alpha channel contains the
transparency data for the merged result.

According to:
http://www.adobe.com/devnet-apps/photoshop/fileformatashtml/PhotoshopFileFormats.htm#50577409_16000
